### PR TITLE
Fix the gradient calculation bug related to background color

### DIFF
--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/forward.cu
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/forward.cu
@@ -286,6 +286,7 @@ renderCUDA(
 	float* __restrict__ final_T,
 	uint32_t* __restrict__ n_contrib,
 	uint32_t* __restrict__ max_contrib,
+	float* __restrict__ pixel_colors,
 	const float* __restrict__ bg_color,
 	float* __restrict__ out_color,
 	int* __restrict__ count_contrib,
@@ -423,7 +424,10 @@ renderCUDA(
 		final_T[pix_id] = T;
 		n_contrib[pix_id] = last_contributor;
 		for (int ch = 0; ch < CHANNELS; ch++)
+		{
+			pixel_colors[ch * H * W + pix_id] = C[ch];
 			out_color[ch * H * W + pix_id] = C[ch] + T * bg_color[ch];
+		}
 
 		if(count_contrib)
 			count_contrib[pix_id] = contribs;
@@ -452,6 +456,7 @@ void FORWARD::render(
 	float* final_T,
 	uint32_t* n_contrib,
 	uint32_t* max_contrib,
+	float* pixel_colors,
 	const float* bg_color,
 	float* out_color,
 	int* img_contrib_counts,
@@ -479,6 +484,7 @@ void FORWARD::render(
 		final_T,
 		n_contrib,
 		max_contrib,
+		pixel_colors,
 		bg_color,
 		out_color,
 		img_contrib_counts,

--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/forward.h
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/forward.h
@@ -66,6 +66,7 @@ namespace FORWARD
 		float* final_T,
 		uint32_t* n_contrib,
 		uint32_t* max_contrib,
+		float* pixel_colors,
 		const float* bg_color,
 		float* out_color,
 		int* img_contribs,

--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/rasterizer_impl.cu
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/rasterizer_impl.cu
@@ -495,6 +495,7 @@ std::tuple<int,int> CudaRasterizer::Rasterizer::forward(
 		imgState.accum_alpha,
 		imgState.n_contrib,
 		imgState.max_contrib,
+		imgState.pixel_colors,
 		background,
 		out_color,
 		contribCountBuffer,
@@ -508,7 +509,6 @@ std::tuple<int,int> CudaRasterizer::Rasterizer::forward(
 		blend_weights,
 		dist_accum), debug)
 
-	CHECK_CUDA(cudaMemcpy(imgState.pixel_colors, out_color, sizeof(float) * width * height * NUM_CHAFFELS, cudaMemcpyDeviceToDevice), debug);
 	return std::make_tuple(num_rendered, bucket_sum);
 }
 


### PR DESCRIPTION
Fixed the gradient calculation issue related to background color, which is consistent with the issue in [pull request 2](https://github.com/humansensinglab/taming-3dgs/pull/2) (not sure why the current main branch no longer contains the code from pull request 2). 
Used a more reliable way to fix the issue by recording pixel_colors that exclude the background color during the forward process. 
The approach in pull request 2 might run into problems, if there’s any custom logic in the forward process that skips the subsequent gaussians rendering.